### PR TITLE
media backup scheduler configured

### DIFF
--- a/api/management/commands/scheduler.py
+++ b/api/management/commands/scheduler.py
@@ -24,6 +24,14 @@ def backup_db_every_month():
     except Exception as e:
         print(f"An error occurred during database backup: {e}")
 
+# Funtion to backup media
+def backup_media_every_month():
+    try:
+        call_command('mediabackup', clean=True)
+        print("Media files backed up successfully.")
+    except Exception as e:
+        print(f"An error occurred during media backup: {e}")
+
 # Function to delete old job executions
 @util.close_old_connections  # Ensures database connections are closed properly
 def delete_old_job_executions(max_age=7):
@@ -50,6 +58,15 @@ def start():
         trigger=CronTrigger(day='last', hour=23, minute=59),  # Run on the last day of every month at 11:59 PM
         jobstore='default',
         id="db_backup",
+        replace_existing=True,
+    )
+
+    # Add a job to backup media files every month
+    scheduler.add_job(
+        backup_media_every_month,
+        trigger=CronTrigger(day='last', hour=23, minute=45),  # 15 mins before DB backup
+        jobstore='default',
+        id="media_backup",
         replace_existing=True,
     )
 

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -135,11 +135,19 @@ MEDIA_ROOT = BASE_DIR / '../media'
 # STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Backup settings
+def db_backup_filename(databasename, servername, datetime, extension, content_type):
+    return f"db/{datetime}.{extension}"
+
+def media_backup_filename(databasename, servername, datetime, extension, content_type):
+    return f"media/{datetime}.{extension}"
+
 DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
 DBBACKUP_STORAGE_OPTIONS = {'location': BASE_DIR / '../backups'}
 DBBACKUP_TMP_FILE_MAX_SIZE = 10*1024*1024
 DBBACKUP_CLEANUP_KEEP = 3
-
+DBBACKUP_CLEANUP_KEEP_MEDIA = 3
+DBBACKUP_FILENAME_TEMPLATE = db_backup_filename
+DBBACKUP_MEDIA_FILENAME_TEMPLATE = media_backup_filename
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
feat: add media backup scheduler and custom filename templates

- Created a scheduled job to back up media files monthly
- Implemented custom filename templates for both DB and media backups
- Organized backups into 'db/' and 'media/' folders for clarity
